### PR TITLE
⚡ Optimize scraper service with concurrent fetching

### DIFF
--- a/src/services/scraperService.ts
+++ b/src/services/scraperService.ts
@@ -16,7 +16,8 @@ export const ScraperService = {
             { name: 'TTC (Regular)', url: 'https://career17.sapsf.com/career?company=TTCPRODUCTION', source: 'ttc-sap' }
         ];
 
-        for (const target of targets) {
+        // Run all scrapers concurrently
+        const scrapers = targets.map(async (target) => {
             try {
                 let rawJobs: Array<{ title: string; url: string; company: string; location: string; postedDate: string | null }> = [];
                 console.log(`[${target.name}] Fetching from ${target.url.substring(0, 50)}...`);
@@ -88,12 +89,15 @@ export const ScraperService = {
                     };
                 });
 
-                jobs.push(...normalized);
-
+                return normalized;
             } catch (err) {
                 console.error(`Failed to scrape ${target.name}:`, err);
+                return [];
             }
-        }
+        });
+
+        const results = await Promise.all(scrapers);
+        jobs.push(...results.flat());
 
         if (jobs.length === 0) {
             console.warn('All scrapers failed, returning mock data.');


### PR DESCRIPTION
The `getFeed` function in `ScraperService` was previously fetching job targets sequentially using a `for...of` loop. This meant that the total time taken was the sum of all individual network requests. By refactoring the loop to use `Promise.all` with `targets.map`, the scraping process now runs concurrently. 

Independent error handling has been preserved for each target to ensure that if one scraping task fails, others can still complete successfully. This change improves the responsiveness of the job feed fetching process.