### PR TITLE
🧪 Improve tests for areBlocksEqual logic

### DIFF
--- a/src/services/storage/blockUtils.test.ts
+++ b/src/services/storage/blockUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { areBlocksEqual } from './blockUtils';
+
+describe('areBlocksEqual', () => {
+    describe('Type matching', () => {
+        it('should return false if types are different', () => {
+            const a = { type: 'work', title: 'Engineer' };
+            const b = { type: 'education', title: 'Engineer' };
+            expect(areBlocksEqual(a, b)).toBe(false);
+        });
+    });
+
+    describe('work, education, project types', () => {
+        const types = ['work', 'education', 'project'];
+
+        types.forEach(type => {
+            it(`should return true for ${type} if title and organization match exactly`, () => {
+                const a = { type, title: 'Software Engineer', organization: 'Tech Corp' };
+                const b = { type, title: 'Software Engineer', organization: 'Tech Corp' };
+                expect(areBlocksEqual(a, b)).toBe(true);
+            });
+
+            it(`should return true for ${type} if title and organization match with different case and whitespace`, () => {
+                const a = { type, title: 'Software Engineer', organization: 'Tech Corp' };
+                const b = { type, title: '  software engineer  ', organization: '  TECH CORP  ' };
+                expect(areBlocksEqual(a, b)).toBe(true);
+            });
+
+            it(`should return false for ${type} if titles are different`, () => {
+                const a = { type, title: 'Software Engineer', organization: 'Tech Corp' };
+                const b = { type, title: 'Hardware Engineer', organization: 'Tech Corp' };
+                expect(areBlocksEqual(a, b)).toBe(false);
+            });
+
+            it(`should return false for ${type} if organizations are different`, () => {
+                const a = { type, title: 'Software Engineer', organization: 'Tech Corp' };
+                const b = { type, title: 'Software Engineer', organization: 'Other Corp' };
+                expect(areBlocksEqual(a, b)).toBe(false);
+            });
+
+            it(`should handle missing title or organization for ${type}`, () => {
+                const a = { type };
+                const b = { type, title: '', organization: '' };
+                expect(areBlocksEqual(a, b)).toBe(true);
+            });
+        });
+    });
+
+    describe('skill type', () => {
+        it('should return true if titles match exactly', () => {
+            const a = { type: 'skill', title: 'React' };
+            const b = { type: 'skill', title: 'React' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should return true if titles match with different case and whitespace', () => {
+            const a = { type: 'skill', title: 'React' };
+            const b = { type: 'skill', title: '  react  ' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should return false if titles are different', () => {
+            const a = { type: 'skill', title: 'React' };
+            const b = { type: 'skill', title: 'Vue' };
+            expect(areBlocksEqual(a, b)).toBe(false);
+        });
+
+        it('should ignore organization for skill type', () => {
+            const a = { type: 'skill', title: 'React', organization: 'A' };
+            const b = { type: 'skill', title: 'React', organization: 'B' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+    });
+
+    describe('summary type', () => {
+        it('should always return true if types match', () => {
+            const a = { type: 'summary', title: 'Summary A' };
+            const b = { type: 'summary', title: 'Summary B' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+    });
+
+    describe('other types', () => {
+        it('should return false for unknown types', () => {
+            const a = { type: 'unknown', title: 'Test' };
+            const b = { type: 'unknown', title: 'Test' };
+            expect(areBlocksEqual(a, b)).toBe(false);
+        });
+    });
+});

--- a/src/services/storage/blockUtils.ts
+++ b/src/services/storage/blockUtils.ts
@@ -1,0 +1,14 @@
+export const areBlocksEqual = (a: { type: string; title?: string; organization?: string }, b: { type: string; title?: string; organization?: string }) => {
+    if (a.type !== b.type) return false;
+    const normTitleA = (a.title || "").toLowerCase().trim();
+    const normTitleB = (b.title || "").toLowerCase().trim();
+    const normOrgA = (a.organization || "").toLowerCase().trim();
+    const normOrgB = (b.organization || "").toLowerCase().trim();
+
+    if (['work', 'education', 'project'].includes(a.type)) {
+        return normTitleA === normTitleB && normOrgA === normOrgB;
+    }
+    if (a.type === 'skill') return normTitleA === normTitleB;
+    if (a.type === 'summary') return true;
+    return false;
+};

--- a/src/services/storage/storageCore.ts
+++ b/src/services/storage/storageCore.ts
@@ -63,17 +63,4 @@ export const Vault = {
     }
 };
 
-export const areBlocksEqual = (a: { type: string; title?: string; organization?: string }, b: { type: string; title?: string; organization?: string }) => {
-    if (a.type !== b.type) return false;
-    const normTitleA = (a.title || "").toLowerCase().trim();
-    const normTitleB = (b.title || "").toLowerCase().trim();
-    const normOrgA = (a.organization || "").toLowerCase().trim();
-    const normOrgB = (b.organization || "").toLowerCase().trim();
-
-    if (['work', 'education', 'project'].includes(a.type)) {
-        return normTitleA === normTitleB && normOrgA === normOrgB;
-    }
-    if (a.type === 'skill') return normTitleA === normTitleB;
-    if (a.type === 'summary') return true;
-    return false;
-};
+export { areBlocksEqual } from './blockUtils';


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the untested `areBlocksEqual` function in `storageCore.ts`. This function is responsible for comparing different types of resume/job blocks.

📊 **Coverage:** What scenarios are now tested:
- Type mismatch: Returns `false` if block types differ.
- 'work', 'education', 'project' types: Matches based on both `title` and `organization`, with case-insensitivity and whitespace trimming.
- 'skill' type: Matches based on `title` only, with case-insensitivity and whitespace trimming.
- 'summary' type: Always returns `true` if the types match.
- Unknown types: Returns `false` by default.
- Edge cases: Handles missing `title` or `organization` (null/undefined/empty string).

✨ **Result:** Improved test coverage and reliability. The refactoring also improved the codebase architecture by isolating pure utility logic from service-level side-effects.