### PR TITLE
🧹 Centralize BentoCardConfig type definition

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -289,6 +289,8 @@ export const BENTO_CARDS = {
   }
 } as const;
 
+export type BentoCardConfig = typeof BENTO_CARDS[keyof typeof BENTO_CARDS];
+
 // Marketing Headlines
 export const HEADLINES = {
   all: [

--- a/src/modules/job/FeatureGrid.tsx
+++ b/src/modules/job/FeatureGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { TrendingUp, PenTool, Sparkles, FileText, GraduationCap, Bookmark, Zap } from 'lucide-react';
 import { BentoCard, type BentoColorConfig } from '../../components/common/BentoCard';
-import { BENTO_CARDS } from '../../constants';
+import { BENTO_CARDS, type BentoCardConfig } from '../../constants';
 import { EventService } from '../../services/eventService';
 import type { User } from '@supabase/supabase-js';
 
@@ -15,8 +15,6 @@ const ICON_MAP = {
     Bookmark,
     PenTool
 } as const;
-
-type BentoCardConfig = typeof BENTO_CARDS[keyof typeof BENTO_CARDS];
 
 interface FeatureGridProps {
     user: User | null;


### PR DESCRIPTION
🎯 **What:** Exported `BentoCardConfig` from `src/constants.ts` and updated `src/modules/job/FeatureGrid.tsx` to use the shared type.
💡 **Why:** Improves code health by centralizing the type definition for the `BENTO_CARDS` configuration, making it reusable across the application and removing local duplication. This ensures `config` parameters dealing with `BENTO_CARDS` are consistently typed.
✅ **Verification:**
- Ran `npm run build` to verify type safety.
- Ran `npm test` to ensure no regressions.
- Verified `FeatureGrid.tsx` imports and uses the shared type.
- Cleaned up environment artifacts (`bun.lock`).
✨ **Result:** `BentoCardConfig` is now a shared type available from `src/constants.ts`.

---
*PR created automatically by Jules for task [12719874187882198770](https://jules.google.com/task/12719874187882198770) started by @ryanphanna*