### PR TITLE
test: improve coverage and robustness of `areBlocksEqual`

### DIFF
--- a/src/services/storage/blockUtils.test.ts
+++ b/src/services/storage/blockUtils.test.ts
@@ -87,4 +87,46 @@ describe('areBlocksEqual', () => {
             expect(areBlocksEqual(a, b)).toBe(false);
         });
     });
+
+    describe('Robustness and Edge Cases', () => {
+        it('should treat whitespace-only title as empty string', () => {
+            const a = { type: 'work', title: '   ', organization: 'Tech Corp' };
+            const b = { type: 'work', title: '', organization: 'Tech Corp' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should treat whitespace-only organization as empty string', () => {
+            const a = { type: 'work', title: 'Dev', organization: '   ' };
+            const b = { type: 'work', title: 'Dev', organization: '' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should handle explicitly null fields gracefully', () => {
+            // @ts-expect-error - testing runtime behavior
+            const a = { type: 'work', title: null, organization: 'Tech Corp' };
+            const b = { type: 'work', title: '', organization: 'Tech Corp' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should handle non-string title by converting to string', () => {
+            // @ts-expect-error - testing runtime behavior
+            const a = { type: 'work', title: 123, organization: 'Tech Corp' };
+            const b = { type: 'work', title: '123', organization: 'Tech Corp' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should handle non-string organization by converting to string', () => {
+            // @ts-expect-error - testing runtime behavior
+            const a = { type: 'work', title: 'Dev', organization: { name: 'Corp' } };
+            // Object.toString() is [object Object]
+            const b = { type: 'work', title: 'Dev', organization: '[object Object]' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+
+        it('should handle undefined fields gracefully', () => {
+            const a = { type: 'work', title: undefined, organization: 'Tech Corp' };
+            const b = { type: 'work', title: '', organization: 'Tech Corp' };
+            expect(areBlocksEqual(a, b)).toBe(true);
+        });
+    });
 });

--- a/src/services/storage/blockUtils.ts
+++ b/src/services/storage/blockUtils.ts
@@ -1,9 +1,9 @@
 export const areBlocksEqual = (a: { type: string; title?: string; organization?: string }, b: { type: string; title?: string; organization?: string }) => {
     if (a.type !== b.type) return false;
-    const normTitleA = (a.title || "").toLowerCase().trim();
-    const normTitleB = (b.title || "").toLowerCase().trim();
-    const normOrgA = (a.organization || "").toLowerCase().trim();
-    const normOrgB = (b.organization || "").toLowerCase().trim();
+    const normTitleA = String(a.title || "").toLowerCase().trim();
+    const normTitleB = String(b.title || "").toLowerCase().trim();
+    const normOrgA = String(a.organization || "").toLowerCase().trim();
+    const normOrgB = String(b.organization || "").toLowerCase().trim();
 
     if (['work', 'education', 'project'].includes(a.type)) {
         return normTitleA === normTitleB && normOrgA === normOrgB;

--- a/src/services/storage/storageCore.test.ts
+++ b/src/services/storage/storageCore.test.ts
@@ -1,0 +1,17 @@
+
+import { describe, it, expect } from 'vitest';
+import { areBlocksEqual } from './storageCore';
+
+describe('areBlocksEqual (exported from storageCore)', () => {
+    it('should correctly compare two equal blocks', () => {
+        const a = { type: 'work', title: 'Developer', organization: 'Company A' };
+        const b = { type: 'work', title: 'Developer', organization: 'Company A' };
+        expect(areBlocksEqual(a, b)).toBe(true);
+    });
+
+    it('should correctly compare two different blocks', () => {
+        const a = { type: 'work', title: 'Developer', organization: 'Company A' };
+        const b = { type: 'work', title: 'Manager', organization: 'Company A' };
+        expect(areBlocksEqual(a, b)).toBe(false);
+    });
+});


### PR DESCRIPTION
Improved testing coverage and robustness for the `areBlocksEqual` function. This addresses the gap identified in `src/services/storage/storageCore.ts:66` by ensuring the exported logic is both tested and robust against malformed data.

Changes:
- Created `src/services/storage/storageCore.test.ts` to test the re-export.
- Added extensive test cases to `src/services/storage/blockUtils.test.ts` for runtime type safety (numbers, objects, nulls) and whitespace handling.
- Hardened `areBlocksEqual` implementation to gracefully handle non-string values for `title` and `organization`.

---
*PR created automatically by Jules for task [7367950509858676647](https://jules.google.com/task/7367950509858676647) started by @ryanphanna*