### PR TITLE
Refactor: Strict typing for CoachDashboard view prop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { ErrorBoundary } from './components/common/ErrorBoundary';
 // New layout components
 import { Header } from './components/layout/Header';
 import { GlobalModals } from './components/layout/GlobalModals';
+import { isCoachView } from './modules/career/types';
 
 const AppContent: React.FC = () => {
   // Consume Contexts
@@ -314,7 +315,7 @@ const AppContent: React.FC = () => {
                     resumes={resumes}
                     transcript={transcript}
                     activeAnalysisIds={activeAnalysisIds}
-                    view={typeof currentView === 'string' && currentView.startsWith('coach') ? (currentView as any) : 'coach-home'}
+                    view={isCoachView(currentView) ? currentView : 'coach-home'}
                     onViewChange={handleViewChange}
                     onAddRoleModel={handleAddRoleModel}
                     onAddTargetJob={handleTargetJobCreated}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ interface HeaderProps {
     currentView: string;
     isCoachMode: boolean;
     isEduMode: boolean;
-    onViewChange: (view: any) => void;
+    onViewChange: (view: string) => void;
     onSignOut: () => void;
     onShowSettings: () => void;
     onShowAuth: () => void;

--- a/src/modules/career/CoachDashboard.tsx
+++ b/src/modules/career/CoachDashboard.tsx
@@ -10,8 +10,7 @@ import { RoleModelSection } from './components/RoleModelSection';
 import { GapAnalysisSection } from './components/GapAnalysisSection';
 import { RoleModelComparison } from './components/RoleModelComparison';
 import type { ResumeProfile } from '../resume/types';
-
-export type CoachViewType = 'coach-home' | 'coach-role-models' | 'coach-gap-analysis' | 'coach-comparison';
+import type { CoachViewType } from './types';
 
 interface CoachDashboardProps {
     userSkills: CustomSkill[];

--- a/src/modules/career/types.ts
+++ b/src/modules/career/types.ts
@@ -1,0 +1,7 @@
+export const COACH_VIEWS = ['coach-home', 'coach-role-models', 'coach-gap-analysis', 'coach-comparison'] as const;
+
+export type CoachViewType = typeof COACH_VIEWS[number];
+
+export const isCoachView = (view: string): view is CoachViewType => {
+    return (COACH_VIEWS as readonly string[]).includes(view);
+};


### PR DESCRIPTION
This PR addresses a code health issue where `any` was used for the `view` prop in `CoachDashboard` and related components.

Changes:
- **New File:** `src/modules/career/types.ts` containing `COACH_VIEWS` constant, `CoachViewType` definition, and `isCoachView` type guard.
- **Refactor:** `CoachDashboard.tsx` now imports `CoachViewType` from the new types file.
- **Fix:** `App.tsx` uses `isCoachView` to validate `currentView` before passing it to `CoachDashboard`, replacing an unsafe `as any` cast.
- **Fix:** `Header.tsx` updates `onViewChange` prop type from `any` to `string`.

This improves type safety and maintainability by centralizing the view type definition and ensuring runtime validation of view state.

---
*PR created automatically by Jules for task [1384714977246217842](https://jules.google.com/task/1384714977246217842) started by @ryanphanna*