### PR TITLE
Refactor: Replace useEffect with refs and render-time logic

### DIFF
--- a/src/components/ViewTransition.tsx
+++ b/src/components/ViewTransition.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface ViewTransitionProps {
     children: React.ReactNode;
@@ -16,14 +16,13 @@ export const ViewTransition: React.FC<ViewTransitionProps> = ({
     className = ''
 }) => {
     const [isVisible, setIsVisible] = useState(false);
-    const [currentKey, setCurrentKey] = useState(viewKey);
+    const currentKeyRef = useRef(viewKey);
 
     useEffect(() => {
-        // When viewKey changes, trigger re-animation
-        if (viewKey !== currentKey) {
+        if (viewKey !== currentKeyRef.current) {
+            // viewKey changed — trigger re-animation
             setIsVisible(false);
-            setCurrentKey(viewKey);
-            // Small delay before showing new content
+            currentKeyRef.current = viewKey;
             const timer = setTimeout(() => setIsVisible(true), 50);
             return () => clearTimeout(timer);
         } else {
@@ -31,8 +30,7 @@ export const ViewTransition: React.FC<ViewTransitionProps> = ({
             const timer = setTimeout(() => setIsVisible(true), 10);
             return () => clearTimeout(timer);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [viewKey, currentKey]);
+    }, [viewKey]);
 
     return (
         <div

--- a/src/components/edu/CourseEditModal.tsx
+++ b/src/components/edu/CourseEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { X, Save, Trash2, AlertCircle } from 'lucide-react';
 import type { Course } from '../../types';
 
@@ -19,12 +19,16 @@ export const CourseEditModal: React.FC<CourseEditModalProps> = ({
 }) => {
     const [editedCourse, setEditedCourse] = useState<Course>(course);
     const [confirmDelete, setConfirmDelete] = useState(false);
+    const [prevCourse, setPrevCourse] = useState<Course>(course);
+    const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
 
-    useEffect(() => {
+    // Sync form state when course or open state changes (avoids setState-in-effect)
+    if (course !== prevCourse || isOpen !== prevIsOpen) {
+        setPrevCourse(course);
+        setPrevIsOpen(isOpen);
         setEditedCourse(course);
         setConfirmDelete(false);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [course, isOpen]);
+    }
 
     if (!isOpen) return null;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,10 +63,6 @@ function validateEnv(): { env: Env | null; errors: string[] } {
 // Validate on module load
 const validation = validateEnv();
 
-if (validation.env && import.meta.env.PROD) {
-  console.log('Environment variables validated successfully');
-}
-
 // Export validation state for the app to check
 export const env = validation.env;
 export const envErrors = validation.errors;

--- a/src/hooks/useHeadlines.ts
+++ b/src/hooks/useHeadlines.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { HEADLINES } from '../constants';
 
 type HeadlineType = 'all' | 'apply' | 'goal' | 'edu' | 'plans';
@@ -10,13 +10,16 @@ interface Headline {
 
 export const useHeadlines = (type: HeadlineType) => {
     const choices = useMemo(() => HEADLINES[type], [type]);
-    const [activeHeadline, setActiveHeadline] = useState<Headline>(choices[0]);
+    const [activeHeadline, setActiveHeadline] = useState<Headline>(
+        () => choices[Math.floor(Math.random() * choices.length)]
+    );
+    const [prevChoices, setPrevChoices] = useState(choices);
 
-    useEffect(() => {
-        const randomChoice = choices[Math.floor(Math.random() * choices.length)];
-        setActiveHeadline(randomChoice);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [choices]);
+    // Re-pick when type changes (avoids setState-in-effect)
+    if (choices !== prevChoices) {
+        setPrevChoices(choices);
+        setActiveHeadline(choices[Math.floor(Math.random() * choices.length)]);
+    }
 
     return activeHeadline;
 };

--- a/src/modules/features/FeaturesPage.tsx
+++ b/src/modules/features/FeaturesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -40,20 +40,19 @@ const TIER_LEVEL: Record<Exclude<Tier, 'all'>, number> = { explorer: 0, plus: 1,
 
 export const FeaturesPage: React.FC = () => {
     const [activeTier, setActiveTier] = useState<Tier>('all');
-    const [hasSetDefault, setHasSetDefault] = useState(false);
+    const hasSetDefaultRef = useRef(false);
     const navigate = useNavigate();
     const { user, userTier, isLoading } = useUser();
     const { openModal } = useModal();
 
     useEffect(() => {
-        if (!isLoading && !hasSetDefault && user) {
-            setHasSetDefault(true);
+        if (!isLoading && !hasSetDefaultRef.current && user) {
+            hasSetDefaultRef.current = true;
             if (userTier !== 'free' && userTier !== 'admin') {
                 setActiveTier(userTier as Tier);
             }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [user, userTier, isLoading, hasSetDefault]);
+    }, [user, userTier, isLoading]);
 
     // Get all features from registry (excluding admin-only for public features page)
     const allFeatures = useMemo(() => {

--- a/src/modules/job/CoverLetterEditor.tsx
+++ b/src/modules/job/CoverLetterEditor.tsx
@@ -133,8 +133,6 @@ export const CoverLetterEditor: React.FC<CoverLetterEditorProps> = ({
                 setLocalJob(updated);
                 onJobUpdate(updated);
                 EventService.trackUsage(TRACKING_EVENTS.COVER_LETTERS);
-
-                console.log(`[Pro] Cover letter generated with quality score: ${result.score}/100 (${result.attempts} attempts)`);
             } else {
                 const { text: letter, promptVersion } = await generateCoverLetter(
                     textToUse,
@@ -217,7 +215,6 @@ export const CoverLetterEditor: React.FC<CoverLetterEditorProps> = ({
     // Auto-Generate on Mount if no letter exists
     React.useEffect(() => {
         if (!localJob.coverLetter && !generating && !localJob.coverLetterCritique) {
-            console.log("Auto-generating cover letter draft...");
             handleGenerateCoverLetter();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/modules/job/InterviewAdvisor.tsx
+++ b/src/modules/job/InterviewAdvisor.tsx
@@ -42,6 +42,13 @@ export const InterviewAdvisor: React.FC = () => {
     const [userResponse, setUserResponse] = useState('');
     const navigate = useNavigate();
 
+    const messagesEndRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        if (mode === 'session') {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }
+    }, [responses, currentQuestionIndex, isLoading, mode]);
+
     const handleStartTailored = () => {
         const job = jobs.find(j => j.id === selectedJobId);
         if (job) {
@@ -101,14 +108,6 @@ export const InterviewAdvisor: React.FC = () => {
         }
 
         const currentQ = questions[currentQuestionIndex];
-
-        // Auto-scroll logic
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const messagesEndRef = React.useRef<HTMLDivElement>(null);
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        React.useEffect(() => {
-            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-        }, [responses, currentQuestionIndex, isLoading]);
 
         // Build history with defensive checks
         const conversationHistory = questions.slice(0, currentQuestionIndex + 1).map((q) => ({

--- a/src/modules/job/NavigatorPro.tsx
+++ b/src/modules/job/NavigatorPro.tsx
@@ -45,7 +45,6 @@ export const NavigatorPro: React.FC<NavigatorProProps> = ({ onDraftApplication, 
             const age = Date.now() - parseInt(cachedTimestamp);
             if (age < ONE_DAY) {
                 // Use cached data
-                console.log('Using cached feed data');
                 setFeed(JSON.parse(cachedData));
                 setLoading(false);
                 return;
@@ -100,8 +99,6 @@ export const NavigatorPro: React.FC<NavigatorProProps> = ({ onDraftApplication, 
     };
 
     const analyzeJobsInBackground = async (jobs: JobFeedItem[]) => {
-        console.log('Starting background analysis...');
-
         // Get user's resume and tier
         const { data: resumes } = await supabase
             .from('resumes')
@@ -110,7 +107,6 @@ export const NavigatorPro: React.FC<NavigatorProProps> = ({ onDraftApplication, 
             .limit(1);
 
         if (!resumes || resumes.length === 0) {
-            console.log('No resume found, skipping analysis');
             return;
         }
 
@@ -140,7 +136,6 @@ export const NavigatorPro: React.FC<NavigatorProProps> = ({ onDraftApplication, 
             }
         }
 
-        console.log('Background analysis complete!');
     };
 
     const analyzeAndCacheJob = async (job: JobFeedItem, resume: any) => {


### PR DESCRIPTION
## Summary
This PR refactors several components to eliminate unnecessary `useEffect` hooks by using `useRef` for tracking state and moving synchronization logic to render time. This reduces complexity and improves adherence to React best practices by avoiding state updates in effects.

## Key Changes

- **useHeadlines.ts**: Replaced `useEffect` with lazy initialization in `useState` and render-time logic using `prevChoices` ref to detect type changes and re-pick headlines
- **InterviewAdvisor.tsx**: Moved auto-scroll `useEffect` from inside conditional render logic to component top level, properly scoped to session mode
- **ViewTransition.tsx**: Replaced `currentKey` state with `useRef` to track previous viewKey, eliminating unnecessary state updates and simplifying dependency array
- **CourseEditModal.tsx**: Replaced `useEffect` with render-time logic using `prevCourse` and `prevIsOpen` refs to sync form state when props change
- **FeaturesPage.tsx**: Replaced `hasSetDefault` state with `useRef` to track initialization, removing it from dependency array
- **NavigatorPro.tsx**: Removed debug `console.log` statements
- **config.ts**: Removed debug `console.log` statement for environment validation
- **CoverLetterEditor.tsx**: Removed debug `console.log` statements for cover letter generation

## Implementation Details

The refactoring follows a consistent pattern:
- Use `useRef` to track previous values instead of state when the value doesn't need to trigger re-renders
- Move synchronization logic to render time (before return statement) to detect changes
- Simplify `useEffect` dependency arrays by removing refs that don't need to trigger effects
- Remove unnecessary `eslint-disable-next-line react-hooks/exhaustive-deps` comments where applicable

This approach maintains the same behavior while reducing effect complexity and improving code clarity.