### PR TITLE
Prevent multiple summary sections in resume editor

### DIFF
--- a/src/modules/resume/ResumeEditor.tsx
+++ b/src/modules/resume/ResumeEditor.tsx
@@ -81,6 +81,7 @@ const ResumeEditor: React.FC<ResumeEditorProps> = ({
     };
 
     const addBlock = (type: SectionType) => {
+        if (type === 'summary' && blocks.some(b => b.type === 'summary')) return;
         const newBlock: ExperienceBlock = {
             id: crypto.randomUUID(),
             type: type,
@@ -455,12 +456,14 @@ const ResumeEditor: React.FC<ResumeEditorProps> = ({
                                         )}
 
                                         {/* Add Block Button for Section */}
-                                        <button
-                                            onClick={() => addBlock(section.type)}
-                                            className="w-full py-2 flex items-center justify-center gap-2 text-sm font-medium text-neutral-400 hover:text-indigo-600 border border-transparent hover:border-indigo-100 hover:bg-indigo-50 dark:hover:bg-indigo-900/10 rounded-lg transition-all border-dashed"
-                                        >
-                                            <Plus className="w-4 h-4" /> Add {section.label}
-                                        </button>
+                                        {!(section.type === 'summary' && sectionBlocks.length >= 1) && (
+                                            <button
+                                                onClick={() => addBlock(section.type)}
+                                                className="w-full py-2 flex items-center justify-center gap-2 text-sm font-medium text-neutral-400 hover:text-indigo-600 border border-transparent hover:border-indigo-100 hover:bg-indigo-50 dark:hover:bg-indigo-900/10 rounded-lg transition-all border-dashed"
+                                            >
+                                                <Plus className="w-4 h-4" /> Add {section.label}
+                                            </button>
+                                        )}
                                     </div>
                                 </div>
                             );


### PR DESCRIPTION
## Summary
This change prevents users from adding multiple summary sections to a resume by disabling the "Add Summary" button when a summary section already exists.

## Key Changes
- Added validation in the `addBlock()` function to prevent creating duplicate summary sections
- Conditionally render the "Add Block" button to hide it for summary sections when one already exists in the resume

## Implementation Details
The fix uses two complementary approaches:
1. **Function-level guard**: Early return in `addBlock()` if attempting to add a summary when one already exists
2. **UI-level guard**: The "Add {section.label}" button is only rendered if the section is not a summary, or if no summary blocks exist yet

This ensures both programmatic and UI-level prevention of duplicate summary sections, providing a better user experience by hiding the button rather than showing a disabled state.