### PR TITLE
Refactor CourseEditModal to use useEffect for state sync

### DIFF
--- a/src/components/edu/CourseEditModal.tsx
+++ b/src/components/edu/CourseEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, Save, Trash2, AlertCircle } from 'lucide-react';
 import type { Course } from '../../types';
 
@@ -19,16 +19,13 @@ export const CourseEditModal: React.FC<CourseEditModalProps> = ({
 }) => {
     const [editedCourse, setEditedCourse] = useState<Course>(course);
     const [confirmDelete, setConfirmDelete] = useState(false);
-    const [prevCourse, setPrevCourse] = useState<Course>(course);
-    const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
 
-    // Sync form state when course or open state changes (avoids setState-in-effect)
-    if (course !== prevCourse || isOpen !== prevIsOpen) {
-        setPrevCourse(course);
-        setPrevIsOpen(isOpen);
-        setEditedCourse(course);
-        setConfirmDelete(false);
-    }
+    useEffect(() => {
+        if (isOpen) {
+            setEditedCourse(course);
+            setConfirmDelete(false);
+        }
+    }, [course, isOpen]);
 
     if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
Refactored the CourseEditModal component to use the `useEffect` hook instead of render-time state synchronization, improving code clarity and following React best practices.

## Key Changes
- Replaced manual state tracking (`prevCourse` and `prevIsOpen`) with a `useEffect` hook
- Moved form state synchronization logic into the effect, which now runs when `course` or `isOpen` dependencies change
- Simplified the sync logic to only reset form state when the modal is opened
- Added `useEffect` to the React imports

## Implementation Details
The previous implementation used a render-time comparison pattern to detect when the course or modal open state changed, then manually updated state. This approach, while functional, is less idiomatic in modern React.

The new implementation uses `useEffect` with `[course, isOpen]` as dependencies, which is the standard React pattern for synchronizing component state with external changes. The effect only executes the reset logic when `isOpen` is true, preventing unnecessary state updates when the modal is closed.