### PR TITLE
Refactor CoachDashboard view type safety

### DIFF
--- a/src/modules/career/CoachDashboard.tsx
+++ b/src/modules/career/CoachDashboard.tsx
@@ -23,6 +23,7 @@ interface CoachDashboardProps {
     resumes: ResumeProfile[];
     transcript: Transcript | null;
     view: CoachViewType;
+    onViewChange: (view: CoachViewType) => void;
     onAddRoleModel: (file: File) => Promise<void>;
     onAddTargetJob: (url: string) => Promise<void>;
     onUpdateTargetJob: (job: TargetJob) => Promise<void>;
@@ -31,7 +32,6 @@ interface CoachDashboardProps {
     onRunGapAnalysis: (targetJobId: string) => Promise<void>;
     onGenerateRoadmap: (targetJobId: string) => Promise<void>;
     onToggleMilestone: (targetJobId: string, milestoneId: string) => Promise<void>;
-    onViewChange: (view: CoachViewType) => void;
     activeAnalysisIds?: Set<string>;
 }
 
@@ -182,7 +182,7 @@ export const CoachDashboard: React.FC<CoachDashboardProps> = ({
                     roleModels={roleModels}
                     targetJobs={targetJobs}
                     userSkills={userSkills}
-                    onViewChange={(view) => onViewChange(view as CoachViewType)}
+                    onViewChange={onViewChange}
                 />
             )}
 

--- a/src/modules/career/components/CoachHero.tsx
+++ b/src/modules/career/components/CoachHero.tsx
@@ -14,6 +14,7 @@ import {
 import type { CustomSkill, RoleModelProfile, TargetJob } from '../../../types';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
+import type { CoachViewType } from '../types';
 
 interface CoachHeroProps {
     isTargetMode: boolean;
@@ -29,7 +30,7 @@ interface CoachHeroProps {
     roleModels: RoleModelProfile[];
     targetJobs: TargetJob[];
     userSkills: CustomSkill[];
-    onViewChange: (view: string) => void;
+    onViewChange: (view: CoachViewType) => void;
 }
 
 export const CoachHero: React.FC<CoachHeroProps> = ({
@@ -160,7 +161,7 @@ export const CoachHero: React.FC<CoachHeroProps> = ({
                     <div className="w-px h-8 bg-neutral-200 dark:bg-neutral-800" />
 
                     <div
-                        onClick={() => onViewChange('skills' as any)}
+                        onClick={() => onViewChange('skills')}
                         className="flex items-center gap-3 cursor-pointer group transition-all hover:scale-105"
                     >
                         <div className="w-10 h-10 bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 flex items-center justify-center text-neutral-600 dark:text-neutral-400 shadow-sm group-hover:border-accent-primary/50 group-hover:text-accent-primary-hex transition-colors">

--- a/src/modules/career/types.ts
+++ b/src/modules/career/types.ts
@@ -1,4 +1,4 @@
-export const COACH_VIEWS = ['coach-home', 'coach-role-models', 'coach-gap-analysis', 'coach-comparison', 'career-growth'] as const;
+export const COACH_VIEWS = ['coach-home', 'coach-role-models', 'coach-gap-analysis', 'coach-comparison', 'career-growth', 'skills'] as const;
 
 export type CoachViewType = typeof COACH_VIEWS[number];
 


### PR DESCRIPTION
This PR improves code health by replacing loose `string` typing and `any` casts with the strict `CoachViewType` union. 

The `onViewChange` callback in `CoachDashboard` and `CoachHero` now explicitly requires a valid `CoachViewType`. The `'skills'` view, which was previously handled via an `any` cast, has been formally added to the `CoachViewType` definition. This ensures type safety across the component hierarchy and eliminates the need for type assertions.